### PR TITLE
Background task

### DIFF
--- a/app/api/image_api.py
+++ b/app/api/image_api.py
@@ -8,20 +8,28 @@ from uuid import uuid4
 from app import models, schemas
 from app.db.connection import db
 from app.depends.validate_api_key import validate_api_key
-from app.utils.image_utils import get_image_size, resize_image, get_image_extension, get_squared_thumbnail, s3_upload
+from app.utils.image_utils import (
+    get_image_size,
+    resize_image,
+    get_image_extension,
+    get_squared_thumbnail,
+    s3_upload,
+    s3_file_name,
+)
 
 image = APIRouter()
 
 
-@image.post("/upload", response_model=schemas.ImageInfoRES)
+@image.post("/upload", response_model=schemas.ImageInfoRES, status_code=202)
 async def upload_image(
     request: Request,
     body: schemas.UploadImageREQ,
+    bg_task: BackgroundTasks,
     image_group_id: int,
     session: Session = Depends(db.session),
     _=Depends(validate_api_key),
 ):
-
+    t = time.time()
     image_group = models.ImageGroups.get(session, request.state.user.id, image_group_id)
 
     if not image_group:
@@ -42,8 +50,14 @@ async def upload_image(
             images[size] = resized_image
 
     image_detail = {}
+    image_to_save = {}
     for k, v in images.items():
-        image_detail[k] = s3_upload(v, f"{uuid}_{k}.webp", image_group)
+        image_detail[k] = s3_file_name(image_group, f"{uuid}_{k}.webp")
+        image_to_save[k] = {
+            "image": v,
+            "image_group_uuid": image_group.uuid,
+            "image_file_name": f"{uuid}_{k}.webp",
+        }
 
     image_model = models.Images()
     image_model.user_id = request.state.user.id
@@ -56,7 +70,15 @@ async def upload_image(
     session.add(image_model)
     image_group.add_count()
     session.commit()
+    # background_s3_upload(image_to_save)
+    bg_task.add_task(background_s3_upload, image_to_save)
+    print("소요시간", time.time() - t)
     return image_model
+
+
+def background_s3_upload(image_to_save):
+    for k, v in image_to_save.items():
+        s3_upload(v["image"], v["image_group_uuid"], v["image_file_name"])
 
 
 @image.post("/bg-task", status_code=202)

--- a/app/api/image_api.py
+++ b/app/api/image_api.py
@@ -1,4 +1,7 @@
-from fastapi import APIRouter, Depends
+import asyncio
+import time
+
+from fastapi import APIRouter, Depends, BackgroundTasks
 from sqlalchemy.orm import Session
 from starlette.requests import Request
 from uuid import uuid4
@@ -11,7 +14,7 @@ image = APIRouter()
 
 
 @image.post("/upload", response_model=schemas.ImageInfoRES)
-def upload_image(
+async def upload_image(
     request: Request,
     body: schemas.UploadImageREQ,
     image_group_id: int,
@@ -56,24 +59,24 @@ def upload_image(
     return image_model
 
 
-"""
-    있음 user_id = Column(ForeignKey("users.id"), nullable=False)
-    있음 image_group_id = Column(ForeignKey("images_groups.id"), nullable=False)
-    있음 uuid = Column(String(64), nullable=False, default=uuid.uuid4)
-    필요없는 모델 s3_key = Column(String(256), nullable=False)
-    있음 file_name = Column(String(128), nullable=False)
-    필요없는 모델 file_mime = Column(String(64), nullable=False)
-    있음 file_extension = Column(String(16), nullable=False)
-    필요없는 모델 file_size = Column(Integer, nullable=False)
-    있음 total_file_size = Column(Integer, nullable=False)
-    있음 image_url_data = Column(JSON, nullable=False)
-    image_group = relationship("ImageGroups", back_populates="images", uselist=False)
+@image.post("/bg-task", status_code=202)
+async def bg_task_test(
+    bg_task: BackgroundTasks,
+    session: Session = Depends(db.session),
+):
+    # background_task(session)
+    bg_task.add_task(background_task, session)
+    return {"message": "background task started"}
 
-"""
+
+def background_task(session):
+    time.sleep(5)
+    session.query(models.ImageGroups).update({models.ImageGroups.updated_at: "1999-01-05 00:00:00"})
+    session.commit()
 
 
 @image.get("/{image_id}", response_model=schemas.ImageInfoRES)
-def get_image(
+async def get_image(
     request: Request,
     image_id: int,
     session: Session = Depends(db.session),


### PR DESCRIPTION
<br>

### ■ 반영 브랜치

> 작업한 브랜치명 → 반영할 브랜치명 <br>

- `backgroundTask` → `main`

<br>

### [Notion 정리 : FastAPI 백그라운드 태스크1](https://notion.so/321df186bd644f63b88c81902dc40924)
### [Notion 정리 : FastAPI 백그라운드 태스크2](https://notion.so/1a601329f91c490185749353f5536868)

<br>

### 세부 내용 작성

> Notion 정리 시 생략
- 빠른 응답을 위한 방법
  1. https://fastapi.tiangolo.com/tutorial/background-tasks/
  2. 시간이 많이 걸리는 작업을 해야할 때
      1. 이메일 보내기
      2. 카카오톡 보내기
      3. 함께 전달 받은 데이터를 다른 스페이스에 다시 저장해야 할 때
  3. 작업이 실패 했을때도 크리티컬한 문제가 없을 때만.
      1. 이미지 업로드 같은 경우에는 바로 이미지를 사용할 수 없는 경우가 있기에 불가
      2. 카카오톡 발송, 이메일 발송 같은 경우는 가능
      3. 확실한 로깅과 Error Notification 구조를 갖추기
          - try-exception으로 처리하여 exception을 알림으로 받아야 함
  4.  Client에게는 HTTP202로 Accepted, 처리됨이 아니고 수취함 으로 명시하기


- ASGI를 사용하는 FastAPI에서 가능한 기법
- Django에서는 간편한 백그라운드 태스크 불가, Celery 등을 이용하여 비동기로 돌려줘야 함.
- 백그라운드 태스크로 추가하는 함수에는 익셉션 적용 불가